### PR TITLE
feat: implement pre/post command hooks with regex support

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -15,6 +15,10 @@ import { helpMessages } from './constants';
 import { InquirerUIProvider } from '../ui/InquirerUIProvider';
 import { argSpec, Runner, RunnerContext } from './Runner';
 import { getConfig } from '../config/utils';
+import { spawnSync } from 'child_process';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import * as pkgManagerService from '../pkgManager/service';
 
 const runners: Record<string, Runner> = {
     create,
@@ -26,6 +30,120 @@ const runners: Record<string, Runner> = {
     verify,
     convert,
 };
+
+// Helper function to find and run npm lifecycle hooks with regex support in keys
+// Handles both standard npm hooks (e.g., prebuild) and custom regex hooks (e.g., pre:cmd:arg_pattern)
+async function runNpmHook(
+    hookType: 'pre' | 'post',
+    actualCommand: string,       // The actual command invoked (e.g., 'run', 'build')
+    actualArg: string | undefined, // The actual first argument passed (e.g., 'deploy-staging')
+    ui: InquirerUIProvider
+): Promise<{ ran: boolean; success: boolean }> {
+
+    let packageJson: any;
+    try {
+        const packageJsonPath = path.join(process.cwd(), 'package.json');
+        const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
+        packageJson = JSON.parse(packageJsonContent);
+    } catch (error) {
+        return { ran: false, success: true }; // Ignore if no package.json
+    }
+
+    if (!packageJson?.scripts) {
+        return { ran: false, success: true }; // No scripts defined
+    }
+
+    // 1. Check for standard npm lifecycle script (e.g., prebuild, posttest)
+    const standardHookName = `${hookType}${actualCommand}`;
+    if (actualArg === undefined && packageJson.scripts[standardHookName]) {
+        // Standard hook exists and no argument was passed
+        const packageManager = pkgManagerService.detectPackageManager();
+        ui.write(chalk.blue(`Executing standard ${hookType}-hook: ${chalk.bold(`${packageManager} run ${standardHookName}`)}...`));
+        try {
+            const result = pkgManagerService.runCommand('run', [standardHookName]);
+            if (result.status !== 0) {
+                ui.write(chalk.redBright(`Standard ${hookType}-hook script "${standardHookName}" failed with exit code ${result.status}.`));
+                return { ran: true, success: false };
+            }
+            ui.write(chalk.green(`Standard ${hookType}-hook script "${standardHookName}" finished successfully using ${packageManager}.`));
+            return { ran: true, success: true }; // Standard hook executed, finish.
+        } catch (error) {
+            ui.write(chalk.redBright(`Failed to execute standard ${hookType}-hook script "${standardHookName}": ${error}`));
+            return { ran: true, success: false };
+        }
+    }
+
+    // 2. Check for custom regex-based hooks (pre:cmd_pattern:arg_pattern)
+    const hookPrefix = `${hookType}:`; // Prefix is 'pre:' or 'post:'
+
+    // Iterate through all script keys in package.json
+    for (const scriptKey in packageJson.scripts) {
+        if (scriptKey.startsWith(hookPrefix)) {
+            const patternPart = scriptKey.substring(hookPrefix.length);
+            const lastColonIndex = patternPart.lastIndexOf(':');
+
+            let commandPattern: string;
+            let argPattern: string | null;
+
+            if (lastColonIndex !== -1) {
+                commandPattern = patternPart.substring(0, lastColonIndex);
+                argPattern = patternPart.substring(lastColonIndex + 1);
+            } else {
+                // Case like "prebuild" (no argument pattern specified)
+                commandPattern = patternPart;
+                argPattern = null;
+            }
+
+            if (!commandPattern) continue; // Skip if command pattern is empty (e.g., "pre::something")
+
+            try {
+                const commandRegex = new RegExp(`^${commandPattern}$`);
+
+                // Check if command matches
+                if (commandRegex.test(actualCommand)) {
+                    let argMatches = false;
+                    if (argPattern === null) {
+                        // If no arg pattern, match only if no arg was passed
+                        argMatches = actualArg === undefined;
+                    } else if (actualArg !== undefined) {
+                        // If arg pattern exists and arg was passed, test regex
+                        try {
+                            const argRegex = new RegExp(`^${argPattern}$`);
+                            argMatches = argRegex.test(actualArg);
+                        } catch (e) {
+                            ui.write(chalk.yellow(`Warning: Invalid regex for argument pattern in script key "${scriptKey}": ${e}`));
+                            continue; // Skip this key if arg regex is invalid
+                        }
+                    } // Else: argPattern exists, but no actualArg was passed -> no match
+
+                    if (argMatches) {
+                        // Found the first matching hook key for both command and argument
+                        const packageManager = pkgManagerService.detectPackageManager();
+                        ui.write(chalk.blue(`Executing matching ${hookType}-hook: ${chalk.bold(`${packageManager} run ${scriptKey}`)} (cmd_pattern: "${commandPattern}", arg_pattern: "${argPattern ?? 'null'}")...`));
+                        try {
+                            const result = pkgManagerService.runCommand('run', [scriptKey]);
+
+                            if (result.status !== 0) {
+                                ui.write(chalk.redBright(`${hookType}-hook script "${scriptKey}" failed with exit code ${result.status}.`));
+                                return { ran: true, success: false };
+                            }
+                            ui.write(chalk.green(`${hookType}-hook script "${scriptKey}" finished successfully using ${packageManager}.`));
+                            return { ran: true, success: true }; // Return after executing the first match
+                        } catch (error) {
+                            ui.write(chalk.redBright(`Failed to execute ${hookType}-hook script "${scriptKey}": ${error}`));
+                            return { ran: true, success: false };
+                        }
+                    }
+                }
+            } catch (e) {
+                // Ignore invalid regex patterns for the command part
+                ui.write(chalk.yellow(`Warning: Invalid regex for command pattern in script key "${scriptKey}": ${e}`));
+            }
+        }
+    }
+
+    return { ran: false, success: true }; // No matching hook script found
+}
 
 async function main() {
     require('ts-node/register');
@@ -81,7 +199,25 @@ async function main() {
     const ui = new InquirerUIProvider();
 
     try {
+        // --- Pre-hook execution ---
+        const preHookResult = await runNpmHook('pre', command, args._[1], ui);
+        if (!preHookResult.success) {
+            ui.write(chalk.redBright('Aborting command due to pre-hook failure.'));
+            process.exit(1); // Abort if pre-hook failed
+        }
+        // --- End Pre-hook ---
+
         await runner(args, ui, runnerContext);
+
+        // --- Post-hook execution ---
+        // Only run post-hook if pre-hook didn't fail (implied) and runner succeeded
+        const postHookResult = await runNpmHook('post', command, args._[1], ui);
+        if (!postHookResult.success) {
+            // Don't exit, just warn if post-hook fails
+            ui.write(chalk.yellowBright('Warning: post-hook script failed.'));
+        }
+        // --- End Post-hook ---
+
     } catch (e) {
         if (e && typeof e === 'object' && 'message' in e) {
             console.error((e as any).message);

--- a/src/cli/test.ts
+++ b/src/cli/test.ts
@@ -2,6 +2,8 @@ import { Runner } from './Runner';
 import { execSync } from 'child_process';
 import arg from 'arg';
 import { helpArgs, helpMessages } from './constants';
+import * as pkgManagerService from '../pkgManager/service';
+import chalk from 'chalk';
 
 export const test: Runner = async (args, ui) => {
     const localArgs = arg(helpArgs);
@@ -13,5 +15,16 @@ export const test: Runner = async (args, ui) => {
     // Use positional arguments after the 'test' command
     const testArgs = args._.slice(1); // first argument is 'test', needs to be removed
     
-    execSync(`npm test ${testArgs.join(' ')}`, { stdio: 'inherit' });
+    try {
+        // Use the service to run the test command with arguments
+        const result = pkgManagerService.runCommand('test', testArgs);
+        if (result.status !== 0) {
+            // Exit with the same status code as the test runner if it failed
+            process.exit(result.status ?? 1);
+        }
+    } catch (e) {
+        // Handle potential errors during command execution
+        ui.write(chalk.redBright(`Failed to run test command: ${(e as Error).message || e}`));
+        process.exit(1);
+    }
 };

--- a/src/pkgManager/service.ts
+++ b/src/pkgManager/service.ts
@@ -1,0 +1,136 @@
+import { spawnSync, SpawnSyncOptions, SpawnSyncReturns } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
+
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type CommandType = 'install' | 'run' | 'test' | 'view';
+
+// Cache the detected package manager
+let detectedPackageManager: PackageManager | null = null;
+
+/**
+ * Detects the package manager used in the current project.
+ * Prioritizes npm_config_user_agent, then checks for lock files.
+ */
+export function detectPackageManager(): PackageManager {
+    if (detectedPackageManager) {
+        return detectedPackageManager;
+    }
+
+    // 1. Check npm_config_user_agent
+    const userAgent = process.env.npm_config_user_agent;
+    if (userAgent) {
+        const pm = userAgent.split(' ')[0].split('/')[0];
+        if (pm === 'yarn' || pm === 'pnpm' || pm === 'bun') {
+            detectedPackageManager = pm;
+            return pm;
+        }
+         if (pm === 'npm') {
+            detectedPackageManager = pm;
+            return pm;
+        }
+    }
+
+    // 2. Check for lock files (fallback)
+    const CWD = process.cwd();
+    if (existsSync(path.join(CWD, 'yarn.lock'))) {
+        detectedPackageManager = 'yarn';
+        return 'yarn';
+    }
+    if (existsSync(path.join(CWD, 'pnpm-lock.yaml'))) {
+        detectedPackageManager = 'pnpm';
+        return 'pnpm';
+    }
+     if (existsSync(path.join(CWD, 'bun.lockb'))) {
+        detectedPackageManager = 'bun';
+        return 'bun';
+    }
+
+    // Default to npm
+    detectedPackageManager = 'npm';
+    return 'npm';
+}
+
+/**
+ * Runs a package manager command synchronously.
+ * @param command The type of command to run ('install', 'run', 'test', 'view').
+ * @param args Arguments for the command.
+ * @param options Options for spawnSync.
+ * @returns The result of spawnSync.
+ */
+export function runCommand(
+    command: CommandType,
+    args: string[],
+    options?: SpawnSyncOptions
+): SpawnSyncReturns<string | Buffer> {
+    const pm = detectPackageManager();
+    let effectiveArgs: string[] = [];
+
+    switch (command) {
+        case 'install':
+            // Note: 'install' semantics might differ slightly. This uses the basic install command.
+            // For adding specific packages, a different command type might be needed.
+            effectiveArgs = pm === 'yarn' ? ['install'] : ['install']; // yarn install, npm/pnpm/bun install
+            effectiveArgs.push(...args); // Append any extra args like --save-dev
+            break;
+        case 'run':
+            effectiveArgs = ['run', ...args]; // npm run ..., yarn run ..., pnpm run ..., bun run ...
+            break;
+        case 'test':
+            effectiveArgs = ['test', ...args]; // npm test ..., yarn test ..., pnpm test ..., bun test ...
+            break;
+        case 'view':
+            // Note: Command and JSON output support might vary.
+            // yarn info <pkg> versions --json
+            // npm view <pkg> versions --json
+            // pnpm view <pkg> versions --json (Check if --json is supported)
+            // bun ?? (bun pm versions <pkg> doesn't seem to have json output yet) - Falling back to npm for bun view
+             if (pm === 'yarn') {
+                 effectiveArgs = ['info', ...args]; // yarn info expects slightly different args structure
+             } else if (pm === 'bun') {
+                 // Bun's view equivalent lacks JSON output, using npm as fallback for now
+                 console.warn("Warning: 'bun view' equivalent with JSON output not available, using 'npm view' as fallback.");
+                 return spawnSync('npm', ['view', ...args], { stdio: 'pipe', ...options, cwd: options?.cwd ?? process.cwd(), shell: true });
+             }
+              else {
+                 effectiveArgs = ['view', ...args];
+             }
+            break;
+        default:
+            throw new Error(`Unsupported command type: ${command}`);
+    }
+
+    const defaultOptions: SpawnSyncOptions = {
+        stdio: 'inherit', // Default to inherit for visibility
+        shell: true,      // Often needed for `run` scripts
+        cwd: process.cwd(),
+        ...options,       // Allow overriding defaults
+    };
+
+    // Ensure stdio is 'pipe' if we need to capture output (e.g., for 'view')
+    if (command === 'view' && defaultOptions.stdio === 'inherit') {
+        defaultOptions.stdio = 'pipe';
+    }
+
+
+    // console.log(`Running command: ${pm} ${effectiveArgs.join(' ')}`); // For debugging
+    const result = spawnSync(pm, effectiveArgs, defaultOptions);
+
+    // No need to cast to buffer anymore
+    // if (result.stdout && typeof result.stdout === 'string') {
+    //     result.stdout = Buffer.from(result.stdout);
+    // }
+    // if (result.stderr && typeof result.stderr === 'string') {
+    //     result.stderr = Buffer.from(result.stderr);
+    // }
+
+    return result; // Return type now matches spawnSync potential output
+}
+
+/**
+ * Gets the package.json key for overriding dependencies based on the package manager.
+ */
+export function getOverrideKey(): 'resolutions' | 'overrides' {
+    const pm = detectPackageManager();
+    return pm === 'yarn' ? 'resolutions' : 'overrides';
+} 


### PR DESCRIPTION
Implement lifecycle hooks triggered by blueprint commands based on package.json scripts.

Supports two hook formats:

1. Standard npm hooks (e.g., "prebuild") for commands without arguments.

2. Custom regex hooks (e.g., "pre:build:.*", "post:run:deploy\w+") matching command and first argument patterns.

Includes a unified package manager service (npm, yarn, pnpm, bun) for detection and command execution.

Closes #12